### PR TITLE
Draw FPS depending on settings

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -270,8 +270,12 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 		if (!menuStack.isEmpty()) {
 			menuStack.peek().render(screen);
 		}
-
-		// Font.draw(screen, "FPS: " + fps, 10, 10);
+		
+		boolean drawFPS = Options.get("drawFPS") != null && Options.get("drawFPS").equals("true");
+		if ( drawFPS ) {
+			Font.draw(screen, "FPS: " + fps, 10, 10);
+		}
+		
 		// for (int p = 0; p < players.length; p++) {
 		// if (players[p] != null) {
 		// String msg = "P" + (p + 1) + ": " + players[p].getScore();


### PR DESCRIPTION
Uses the new Options class (see #101)

To test this until we have an options dialog (see #105 for missing pieces) insert
`drawFPS=true`
in your `options.properties` file
