### PR TITLE
Mobs can move into walls and pass though walls

### DIFF
--- a/src/com/mojang/mojam/entity/mob/HostileMob.java
+++ b/src/com/mojang/mojam/entity/mob/HostileMob.java
@@ -40,8 +40,8 @@ public abstract class HostileMob extends Mob {
 	}
 	public void tick() {	
 		super.tick();
-		Tile ThisTile = level.getTile((int)pos.x/Tile.WIDTH, (int)pos.y/Tile.HEIGHT);
-		if (!ThisTile.canPass(this)){
+		Tile thisTile = level.getTile((int)pos.x/Tile.WIDTH, (int)pos.y/Tile.HEIGHT);
+		if (!thisTile.canPass(this)){
 			remove();
 		}
 	}


### PR DESCRIPTION
If a mob spawner is right next to a wall and a mob spawns with an initial movement vector towards the wall it can end up moving into the wall and pass over to the other side of the wall due to collisions with the spawner entity and wall bounces. 

This commit removes hostile mobs if they find themselves in a tile they should not be able to pass.
