### PR TITLE
Glitch(bug)fix for out-of-focus-pause

### DIFF
--- a/src/com/mojang/mojam/gui/TitleMenu.java
+++ b/src/com/mojang/mojam/gui/TitleMenu.java
@@ -39,7 +39,6 @@ public class TitleMenu extends GuiMenu {
     public static final int MUSIC = 2003;
     public static final int CREATIVE_ID = 2004;
     public static final int ALTERNATIVE_ID = 2005;
-    public static final int PRIORITY_ID = 2999;
 
 	public static final int KEY_BINDINGS_ID = 3000;
 	public static final int KEY_UP_ID = 3001;


### PR DESCRIPTION
- Added an check if pause menu already opened when launching out-of-focus-pause code 

Edit : The diffs may have got messed up , unneeded line breaks and / or spaces got added or removed . Isn't changing game behaviour in any way .
