### PR TITLE
Removed 'Update Levels' button

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -791,14 +791,14 @@ public class MojamComponent extends Canvas implements Runnable,
 			addMenu(new LevelSelect(false,localTeam));
 		} else if (id == TitleMenu.SELECT_HOST_LEVEL_ID) {
 			addMenu(new LevelSelect(true,localTeam));
-		} else if (id == TitleMenu.UPDATE_LEVELS) {
+		} /*else if (id == TitleMenu.UPDATE_LEVELS) {
 			GuiMenu menu = menuStack.pop();
 			if (menu instanceof LevelSelect) {
 				addMenu(new LevelSelect(((LevelSelect) menu).bHosting, localTeam));
 			} else {
 				addMenu(new LevelSelect(false,localTeam));
 			}
-		} else if (id == TitleMenu.HOST_GAME_ID) {
+		}*/ else if (id == TitleMenu.HOST_GAME_ID) {
 			addMenu(new HostingWaitMenu());
 			isMultiplayer = true;
 			isServer = true;

--- a/src/com/mojang/mojam/gui/LevelSelect.java
+++ b/src/com/mojang/mojam/gui/LevelSelect.java
@@ -52,8 +52,10 @@ public class LevelSelect extends GuiMenu {
 			MojamComponent.GAME_WIDTH - 256 - 30, MojamComponent.GAME_HEIGHT - 24 - 25));
 		cancelButton = (Button) addButton(new Button(TitleMenu.CANCEL_JOIN_ID, MojamComponent.texts.getStatic("cancel"), 
 				MojamComponent.GAME_WIDTH - 128 - 20, MojamComponent.GAME_HEIGHT - 24 - 25));
-		addButton(new Button(TitleMenu.UPDATE_LEVELS, MojamComponent.texts.getStatic("levelselect.update"), 
+		/*addButton(new Button(TitleMenu.UPDATE_LEVELS, MojamComponent.texts.getStatic("levelselect.update"), 
 				MojamComponent.GAME_WIDTH - 128 - 18, 20));
+		 //levels already load by default, no update needed
+		*/
 
 		// Add page buttons
 		if (levels.size() > LEVELS_PER_PAGE) {


### PR DESCRIPTION
Because the game already loads extra levels by default, there is no reason to use it. 'Update Levels' is also misleading and suggests that the game will download new versions of the maps. The code is only commented out just in case.
