### PR TITLE
Can shoot due right in creative mode (and probably improves other movements)

### DIFF
--- a/src/com/mojang/mojam/entity/Entity.java
+++ b/src/com/mojang/mojam/entity/Entity.java
@@ -69,7 +69,7 @@ public abstract class Entity implements BBOwner {
 	
 	protected boolean move(double xa, double ya) {
 		List<BB> bbs = level.getClipBBs(this);
-		if (physicsSlide) {
+		if (physicsSlide || (xa==0||ya==0)) {
 			boolean moved = false;
 			if (!removed)
 				moved |= partMove(bbs, xa, 0);


### PR DESCRIPTION
The move method in entity doesn't allow for entities with no physical slide to move exactly up, down, left or right. 

You can see this problem in creative mode when you try to shoot exactly in the right (x) direction with no y component, this is easiest to do using the keyboard to aim rather than the mouse. The result is that the bullets don't travel in that direction and just vanish. Surprisingly you can shoot straight up, left and down. This is due to a truncation error when atan2 in the rifle class is used to calculate the bullets movement vector however it is causes no truncation when the player aim vector is only in the positive x direction as it then returns 0.0.

The problem is really with the way partMove method is called for entities with no physicalSlide, so i have fixed this.
