### PR TITLE
Fix freeze on game start under debugging

### DIFF
--- a/src/com/mojang/mojam/entity/mob/Mob.java
+++ b/src/com/mojang/mojam/entity/mob/Mob.java
@@ -8,6 +8,7 @@ import com.mojang.mojam.entity.animation.EnemyDieAnimation;
 import com.mojang.mojam.entity.building.Building;
 import com.mojang.mojam.entity.building.SpawnerEntity;
 import com.mojang.mojam.entity.loot.Loot;
+import com.mojang.mojam.level.DifficultyInformation;
 import com.mojang.mojam.level.HoleTile;
 import com.mojang.mojam.gui.TitleMenu;
 import com.mojang.mojam.level.tile.Tile;
@@ -53,11 +54,8 @@ public abstract class Mob extends Entity {
 		this.team = team;
 		this.localTeam = localTeam;
 		healingInterval = 25;
-		try {
-			if (TitleMenu.difficulty.difficultyID == 3) healingInterval = 15; 
-		} catch (Exception e) {
-			
-		}
+		DifficultyInformation difficulty = TitleMenu.difficulty;
+		if (difficulty != null && difficulty.difficultyID == 3) healingInterval = 15;
 		healingTime = healingInterval;
 	}
 


### PR DESCRIPTION
Eclipse debugging freezes due to exceptions

Rather than doing a null check in Mob() we were
just catching NullPointerExceptions which caused
the debugger to pause at the "failing" line.

I think it was creating a bunch of Mob objects to
show the map selection page, but the difficulty
had not been set yet.

Changed to a null check and debugger is happy again.
