### PR TITLE
Bat shadow opacity instead of flicker

### DIFF
--- a/src/com/mojang/mojam/entity/mob/Bat.java
+++ b/src/com/mojang/mojam/entity/mob/Bat.java
@@ -55,12 +55,9 @@ public class Bat extends HostileMob {
 
 	@Override
 	public void render(Screen screen) {
-		if (tick % 2 == 0) {
-			if(!(level.getTile(pos) instanceof HoleTile))
-			screen.blit(Art.batShadow, pos.x - Art.batShadow.w / 2, pos.y
-					- Art.batShadow.h / 2 - yOffs + 16);			
+		if(!(level.getTile(pos) instanceof HoleTile)) {
+			screen.opacityBlit(Art.batShadow, (int)(pos.x - Art.batShadow.w / 2), (int)(pos.y - Art.batShadow.h / 2 - yOffs + 16), 0x99);
 		}
 		super.render(screen);
-
 	}
 }

--- a/src/com/mojang/mojam/screen/Screen.java
+++ b/src/com/mojang/mojam/screen/Screen.java
@@ -29,6 +29,10 @@ public class Screen extends Bitmap {
 	public void blit(Bitmap bitmap, int x, int y, int w, int h) {
 		super.blit(bitmap, x + xOffset, y + yOffset, w, h);
 	}
+	
+	public void opacityBlit(Bitmap bitmap, int x, int y, int opacity) {
+		super.opacityBlit(bitmap, x + xOffset, y + yOffset, opacity);
+	}
 
 	public void colorBlit(Bitmap bitmap, double x, double y, int color) {
 		colorBlit(bitmap, (int) x, (int) y, color);


### PR DESCRIPTION
Currently the bat's shadows are supposed to flicker. But in reality they often glitch out so that they are either mostly on or mostly off.

My solution:
1. Remove the flicker effect
2. Make the bat's shadow transparent instead
