### PR TITLE
turret / ranged entity radius shown on target (hover)

### DIFF
--- a/src/com/mojang/mojam/entity/building/Building.java
+++ b/src/com/mojang/mojam/entity/building/Building.java
@@ -275,6 +275,7 @@ public class Building extends Mob implements IUsable {
 	@Override
 	public void setHighlighted(boolean hl) {
 		highlight = hl;
+		justDroppedTicks = 80;
 	}
 
 	@Override

--- a/src/com/mojang/mojam/entity/building/Harvester.java
+++ b/src/com/mojang/mojam/entity/building/Harvester.java
@@ -143,7 +143,7 @@ public class Harvester extends Building implements LootCollector {
 	@Override
 	public void render(Screen screen) {
 		
-		if(justDroppedTicks-- > 0 && MojamComponent.localTeam==team) {
+		if((justDroppedTicks-- > 0 || highlight) && MojamComponent.localTeam==team) {
 			drawRadius(screen);
 		}
 		

--- a/src/com/mojang/mojam/entity/building/Turret.java
+++ b/src/com/mojang/mojam/entity/building/Turret.java
@@ -111,7 +111,7 @@ public class Turret extends Building {
 	@Override
 	public void render(Screen screen) {
 		
-		if(justDroppedTicks-- > 0 && MojamComponent.localTeam==team) {
+		if((justDroppedTicks-- > 0 || highlight) && MojamComponent.localTeam==team) {
 				drawRadius(screen);
 		}
 		


### PR DESCRIPTION
Pull request for #551

Shows the radius around ranged buildings when they are highlighted.
