### PR TITLE
Set player suck to full when not shooting

### DIFF
--- a/src/com/mojang/mojam/entity/Player.java
+++ b/src/com/mojang/mojam/entity/Player.java
@@ -453,11 +453,10 @@ public class Player extends Mob implements LootCollector {
         } else {
             if (wasShooting) {
                 suckRadius = 0;
+            } else {
+            	suckRadius = 60;
             }
             wasShooting = false;
-            if (suckRadius < 60) {
-                suckRadius++;
-            }
             takeDelay = 15;
         }
     }


### PR DESCRIPTION
Turn on the player's coin-sucking ability instantaneously when not shooting, as discussed in #553.

Note that you still have to stop shooting for a while, as the coins will stop travelling towards you when you start shooting again.
