### PR TITLE
Tooltips and marker fix in multiplayer and cannot upgrade enemy buildings

### DIFF
--- a/src/com/mojang/mojam/entity/building/Building.java
+++ b/src/com/mojang/mojam/entity/building/Building.java
@@ -55,10 +55,9 @@ public class Building extends Mob implements IUsable {
 
 	@Override
 	public void render(Screen screen) {
-		super.render(screen);
-		renderMarker(screen);
-		if(team == MojamComponent.localTeam)
-			renderInfo(screen);
+	    super.render(screen);
+	    renderMarker(screen);
+	    renderInfo(screen);
 	}
 
 	/**
@@ -97,27 +96,25 @@ public class Building extends Mob implements IUsable {
 	 */
 	protected void renderInfo(Screen screen) {
 		// Draw iiAtlas' shop item info graphics, thanks whoever re-wrote this!
-		if (highlight) {
-		    if (this instanceof ShopItem) {
-		        ShopItem s = (ShopItem)this;
-		        Bitmap image = getSprite();
-		        int teamYOffset = (team == 2) ? 90 : 0;
-		        
-		        String[] tooltip = s.getTooltip();
-		        int h = tooltip.length*(Font.FONT_GOLD_SMALL.getFontHeight()+3);
-		        int w = getLongestWidth(tooltip, Font.FONT_WHITE_SMALL)+4;
-		        
-		        Font f = Font.FONT_GOLD_SMALL;
-		        screen.blit(Bitmap.tooltipBitmap(w, h),
-                        (int)(pos.x - image.w / 2 - 10),
-                        (int)(pos.y + 20 - teamYOffset), w, h);
+	    if (highlight && this instanceof ShopItem) {
+	        ShopItem s = (ShopItem)this;
+	        Bitmap image = getSprite();
+	        int teamYOffset = (team == 2) ? 90 : 0;
 
-		        for (int i=0; i<tooltip.length; i++) {
-		            f.draw(screen, tooltip[i], (int)(pos.x - image.w + 8), (int)pos.y + 22 - teamYOffset + (i==0?0:1) + i*(f.getFontHeight()+2));
-		            f = Font.FONT_WHITE_SMALL;
-		        }
-		    }
-		}
+	        String[] tooltip = s.getTooltip();
+	        int h = tooltip.length*(Font.FONT_GOLD_SMALL.getFontHeight()+3);
+	        int w = getLongestWidth(tooltip, Font.FONT_WHITE_SMALL)+4;
+
+	        Font f = Font.FONT_GOLD_SMALL;
+	        screen.blit(Bitmap.tooltipBitmap(w, h),
+	                (int)(pos.x - image.w / 2 - 10),
+	                (int)(pos.y + 20 - teamYOffset), w, h);
+
+	        for (int i=0; i<tooltip.length; i++) {
+	            f.draw(screen, tooltip[i], (int)(pos.x - image.w + 8), (int)pos.y + 22 - teamYOffset + (i==0?0:1) + i*(f.getFontHeight()+2));
+	            f = Font.FONT_WHITE_SMALL;
+	        }
+	    }
 	}
 	
 	private int getLongestWidth(String[] string, Font font) {


### PR DESCRIPTION
Interaction with enemy buildings not allowed
Previously there were a number of issues with highlighting
and markers. This patch changes the functionality to the
following:
- You may only pick up or upgrade buildings you own OR
  buildings owned by the Neutral team. This no longer gives
  a message, it just doesn't work any more (see next point).
- An interaction marker (the pulsing square reticle) only
  appears over a building you can interact with (see above).
  And it only appears on your game client.
- Tool tips only appear on ShopItems you own and only on your
  own game client.

The code in Player#pickup() that shows the message
"You can not pick that up!" when you try and pick up an enemy
building should no longer be executed, but I have not removed
it.

Hopefully the fact that the marker is no longer shown should
make it obvious enough that you cannot interact with the
Building.

That is all.
