### PR TITLE
made enemy team buildings not selectable - replaces #589

### DIFF
--- a/src/com/mojang/mojam/entity/building/Building.java
+++ b/src/com/mojang/mojam/entity/building/Building.java
@@ -7,6 +7,7 @@ import com.mojang.mojam.entity.Entity;
 import com.mojang.mojam.entity.IUsable;
 import com.mojang.mojam.entity.Player;
 import com.mojang.mojam.entity.mob.Mob;
+import com.mojang.mojam.entity.mob.Team;
 import com.mojang.mojam.gui.Font;
 import com.mojang.mojam.gui.Notifications;
 import com.mojang.mojam.math.BB;
@@ -57,8 +58,6 @@ public class Building extends Mob implements IUsable {
 	public void render(Screen screen) {
 		super.render(screen);
 		renderMarker(screen);
-		if(team == MojamComponent.localTeam)
-			renderInfo(screen);
 	}
 
 	/**
@@ -87,46 +86,6 @@ public class Building extends Mob implements IUsable {
 			}
 			screen.blit(marker, bb.x0, bb.y0 - 4);
 		}
-	}
-
-	/**
-	 * Render the shop info onto the given screen
-	 * 
-	 * @param screen
-	 *            Screen
-	 */
-	protected void renderInfo(Screen screen) {
-		// Draw iiAtlas' shop item info graphics, thanks whoever re-wrote this!
-		if (highlight) {
-		    if (this instanceof ShopItem) {
-		        ShopItem s = (ShopItem)this;
-		        Bitmap image = getSprite();
-		        int teamYOffset = (team == 2) ? 90 : 0;
-		        
-		        String[] tooltip = s.getTooltip();
-		        int h = tooltip.length*(Font.FONT_GOLD_SMALL.getFontHeight()+3);
-		        int w = getLongestWidth(tooltip, Font.FONT_WHITE_SMALL)+4;
-		        
-		        Font f = Font.FONT_GOLD_SMALL;
-		        screen.blit(Bitmap.tooltipBitmap(w, h),
-                        (int)(pos.x - image.w / 2 - 10),
-                        (int)(pos.y + 20 - teamYOffset), w, h);
-
-		        for (int i=0; i<tooltip.length; i++) {
-		            f.draw(screen, tooltip[i], (int)(pos.x - image.w + 8), (int)pos.y + 22 - teamYOffset + (i==0?0:1) + i*(f.getFontHeight()+2));
-		            f = Font.FONT_WHITE_SMALL;
-		        }
-		    }
-		}
-	}
-	
-	private int getLongestWidth(String[] string, Font font) {
-		int res = 0;
-		for ( String s : string ) {
-			int w = font.calculateStringWidth(s.trim());
-			res = w > res ? w : res;
-		}
-		return res;
 	}
 
 	@Override
@@ -269,7 +228,7 @@ public class Building extends Mob implements IUsable {
 
 	@Override
 	public boolean isHighlightable() {
-		return true;
+		return this.team == MojamComponent.localTeam || this.team == Team.Neutral;
 	}
 
 	@Override

--- a/src/com/mojang/mojam/entity/building/ShopItem.java
+++ b/src/com/mojang/mojam/entity/building/ShopItem.java
@@ -69,9 +69,49 @@ public class ShopItem extends Building {
     public void render(Screen screen) {
         super.render(screen);
         if(team == MojamComponent.localTeam) {
-            Font.defaultFont().drawCentered(screen, MojamComponent.texts.cost(effectiveCost), (int) (pos.x), (int) (pos.y + 10));
+            Font.defaultFont().drawCentered(screen, MojamComponent.texts.cost(effectiveCost), (int) (pos.x), (int) (pos.y + 10));           
         }
+        renderInfo(screen);
     }
+    
+
+	/**
+	 * Render the shop info text onto the given screen
+	 * 
+	 * @param screen
+	 *            Screen
+	 */
+	protected void renderInfo(Screen screen) {
+		// Draw iiAtlas' shop item info graphics, thanks whoever re-wrote this!
+		if (highlight) {
+		        ShopItem s = (ShopItem)this;
+		        Bitmap image = getSprite();
+		        int teamYOffset = (team == 2) ? 90 : 0;
+		        
+		        String[] tooltip = s.getTooltip();
+		        int h = tooltip.length*(Font.FONT_GOLD_SMALL.getFontHeight()+3);
+		        int w = getLongestWidth(tooltip, Font.FONT_WHITE_SMALL)+4;
+		        
+		        Font f = Font.FONT_GOLD_SMALL;
+		        screen.blit(Bitmap.tooltipBitmap(w, h),
+                        (int)(pos.x - image.w / 2 - 10),
+                        (int)(pos.y + 20 - teamYOffset), w, h);
+
+		        for (int i=0; i<tooltip.length; i++) {
+		            f.draw(screen, tooltip[i], (int)(pos.x - image.w + 8), (int)pos.y + 22 - teamYOffset + (i==0?0:1) + i*(f.getFontHeight()+2));
+		            f = Font.FONT_WHITE_SMALL;
+		        }
+		}
+	}
+	
+	private int getLongestWidth(String[] string, Font font) {
+		int res = 0;
+		for ( String s : string ) {
+			int w = font.calculateStringWidth(s.trim());
+			res = w > res ? w : res;
+		}
+		return res;
+	}
 
     @Override
     public void init() {


### PR DESCRIPTION
This clears up issues with seeing the tooltip, highlight marker, or being able to interact with enemy buildings. Neutral buildings are still fair game.

Small refactoring to move the renderInfo method to ShopItems since that was all the code was working for.

This is a replacement for #589
