### PR TITLE
Build Rails on Sandtiles

### DIFF
--- a/src/com/mojang/mojam/level/tile/SandTile.java
+++ b/src/com/mojang/mojam/level/tile/SandTile.java
@@ -58,7 +58,6 @@ public class SandTile extends Tile {
 		return true;
 	}
 	
-	@Override
 	public Bitmap getBitMapForEditor() {
 		return Art.floorTiles[5][0];
 	}


### PR DESCRIPTION
Now that we have Sandtiles in game, we might want to build Rails on them. Perhaps you intentionally made them not-buildable since it is not most realistic, that one would build rails on pure sand. But on the other hand, the player perhaps expects to be able to build there, too. I don't know, it's just a proposal :).
