### PR TITLE
Fixed "Error in class 'SourceJava Sound': Channel null in method 'stop'"

### DIFF
--- a/src/com/mojang/mojam/sound/SoundPlayer.java
+++ b/src/com/mojang/mojam/sound/SoundPlayer.java
@@ -175,7 +175,7 @@ public class SoundPlayer implements ISoundPlayer {
 				// effect.
 				return playSound(sourceName, x, y, false, index + 1);
 			}
-			getSoundSystem().stop(indexedSourceName);
+			getSoundSystem().cull(indexedSourceName);
 			getSoundSystem().setPriority(indexedSourceName, false);
 			getSoundSystem().setPosition(indexedSourceName, x, y, 0);
 			getSoundSystem().setAttenuation(indexedSourceName, SoundSystemConfig.ATTENUATION_ROLLOFF);
@@ -183,6 +183,7 @@ public class SoundPlayer implements ISoundPlayer {
 			getSoundSystem().setPitch(indexedSourceName, 1.0f);
 			soundVolume = Options.getAsFloat(Options.SOUND, "1.0f");
 			getSoundSystem().setVolume(indexedSourceName, soundVolume);
+			getSoundSystem().activate(indexedSourceName);
 			getSoundSystem().play(indexedSourceName);
 			return true;
 		}


### PR DESCRIPTION
I finally got rid of that annoying message:

```
Error in class 'SourceJava Sound'
    Channel null in method 'stop'
```

It happened because 'channel' was null in `paulscode.sound.Source`. I don't know why and neither do I know if this is a problem or not, but my solution seems to work. I don't use `stop()` anymore but `cull()`. According to the API it stops and flushes the sound source. It then needs to be reactivated before playback. By now I don't see any negative side effects.
