### PR TITLE
Refactored key binding to allow "none" as assigned key

### DIFF
--- a/src/com/mojang/mojam/InputHandler.java
+++ b/src/com/mojang/mojam/InputHandler.java
@@ -2,17 +2,15 @@ package com.mojang.mojam;
 
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Set;
 
 import com.mojang.mojam.Keys.Key;
 
 public class InputHandler implements KeyListener {
 
-	private Map<Integer, Key> mappings = new HashMap<Integer, Key>();
+	private Map<Key, Integer> mappings = new HashMap<Key, Integer>();
 
 	public InputHandler(Keys keys) {
 		// controls
@@ -47,7 +45,7 @@ public class InputHandler implements KeyListener {
 				// default key code will be used
 			}
 		}
-		mappings.put(keyCode, key);
+		mappings.put(key, keyCode);
 	}
 
 	private String getKey(Key key) {
@@ -55,24 +53,24 @@ public class InputHandler implements KeyListener {
 	}
 
 	public void addMapping(Key key, int keyCode) {
-		mappings.put(keyCode, key);
+		// make sure no key is bound to more than one event
+		clearMappings(keyCode);
+		mappings.put(key, keyCode);
 		Options.set(getKey(key), String.valueOf(keyCode));
 	}
 
-	public void clearMappings(Key key) {
-		for (Integer mapping : getMappings(key)) {
-			mappings.remove(mapping);
-		}
-	}
-
-	public List<Integer> getMappings(Key key) {
-		ArrayList<Integer> keyCodes = new ArrayList<Integer>();
-		for (Entry<Integer, Key> entry : mappings.entrySet()) {
-			if (entry.getValue() == key) {
-				keyCodes.add(entry.getKey());
+	private void clearMappings(int keyCode) {
+		Set<Key> keySet = mappings.keySet();
+		for (Key _key : keySet) {
+			if (mappings.get(_key) == keyCode) {
+				mappings.put(_key, KeyEvent.VK_UNDEFINED);
+				Options.set(getKey(_key), String.valueOf(keyCode));
 			}
 		}
-		return keyCodes;
+	}
+	
+	public Integer getKeyEvent(Key key) {
+		return mappings.get(key);
 	}
 
 	@Override
@@ -89,7 +87,12 @@ public class InputHandler implements KeyListener {
 	public void keyTyped(KeyEvent ke) {}
 
 	private void toggle(KeyEvent ke, boolean state) {
-		Key key = mappings.get(ke.getKeyCode());
+		Key key = null;
+		Set<Key> keySet = mappings.keySet();
+		for (Key _key : keySet) {
+			if (mappings.get(_key) == ke.getKeyCode())
+				key = _key;
+		}
 		if (key != null) {
 			key.nextState = state;
 		}

--- a/src/com/mojang/mojam/gui/KeyBindingsMenu.java
+++ b/src/com/mojang/mojam/gui/KeyBindingsMenu.java
@@ -1,7 +1,6 @@
 package com.mojang.mojam.gui;
 
 import java.awt.event.KeyEvent;
-import java.util.List;
 
 import com.mojang.mojam.InputHandler;
 import com.mojang.mojam.Keys;
@@ -90,7 +89,6 @@ public class KeyBindingsMenu extends GuiMenu {
 		int gameWidth = MojamComponent.GAME_WIDTH;
 		int gameHeight = MojamComponent.GAME_HEIGHT;
 		textWidth = (gameWidth - 2 * BORDER - 2 * 32 - 2 * Button.BUTTON_WIDTH) / 2;
-		System.out.println(textWidth);
 		int numRows = 6;
 		int tab1 = BORDER + 32 + textWidth;
 		int tab2 = gameWidth - BORDER - Button.BUTTON_WIDTH;
@@ -130,12 +128,12 @@ public class KeyBindingsMenu extends GuiMenu {
 	}
 
 	private String getMenuText(Key key) {
-		List<Integer> mappings = inputHandler.getMappings(key);
-		if (mappings.size() > 0) {
-			return KeyEvent.getKeyText(mappings.get(0));
-		} else {
-			return "NONE";
+		Integer keyEvent = inputHandler.getKeyEvent(key);
+		if (keyEvent != null && keyEvent != KeyEvent.VK_UNDEFINED) {
+			return KeyEvent.getKeyText(keyEvent);
 		}
+		// TODO put text in translation file
+		return "NONE";
 	}
 
 	@Override
@@ -194,7 +192,6 @@ public class KeyBindingsMenu extends GuiMenu {
 	@Override
 	public void keyPressed(KeyEvent e) {
 		if (selectedKey != null) {
-			inputHandler.clearMappings(selectedKey.getKey());
 			inputHandler.addMapping(selectedKey.getKey(), e.getKeyCode());
 			selectedKey.setLabel(KeyEvent.getKeyText(e.getKeyCode()));
 			selectedKey.setSelected(false);


### PR DESCRIPTION
I've made a little refactoring of the key binding, to allow the assignment of "no key" to a key event. See Issue #621 for more information.

I had to change the hashmap for this. Before it was a one-to-one relation so it didn't really matter what was the key and what the value, but now it is one-to-many because several events can use `KeyEvent.VK_UNDEFINED`.

One more thing. Could someone please tell me how to refresh the Key-bindings menu screen after two keys have changed? Because it now really has to. Just an example why: If you assign "w" to a new event, then the old event is cleared. (This is the default behavior of most emulators. ) But now I need a refresh to make it clear to the user what happened. 
