### PR TITLE
Refactored Falling and Health Regeneration

### DIFF
--- a/src/com/mojang/mojam/entity/building/Building.java
+++ b/src/com/mojang/mojam/entity/building/Building.java
@@ -89,7 +89,9 @@ public abstract class Building extends Mob implements IUsable {
 	@Override
 	public void tick() {
 		super.tick();
-		
+		if (carriedBy == null) {
+			fallDownHole();
+		}
 		xd = 0.0;
 		yd = 0.0;
 	}
@@ -141,7 +143,6 @@ public abstract class Building extends Mob implements IUsable {
 	@Override
 	public void slideMove(double xa, double ya) {
 		super.move(xa, ya);
-		fallDownHole();
 	}
 	
 	/**

--- a/src/com/mojang/mojam/entity/mob/Mob.java
+++ b/src/com/mojang/mojam/entity/mob/Mob.java
@@ -102,7 +102,7 @@ public abstract class Mob extends Entity {
 	}
 
 	public void tick() {
-		if (TitleMenu.difficulty.difficultyID >= 1 || this instanceof RailDroid) {
+		if (TitleMenu.difficulty.difficultyID >= 1 || this.team != Team.Neutral) {
 			this.doRegenTime();
 		}
 		


### PR DESCRIPTION
- Moved check for falling into building's tick method from slideMove, so
  that they fall when the floor falls out from underneath them.
- Allowed all non-neutral mobs to regen health in easy difficulty. i.e.
  Rail Droids, Turrets, Harvesters...
