### PR TITLE
removed unnecessary call of stop() method

### DIFF
--- a/src/com/mojang/mojam/sound/SoundPlayer.java
+++ b/src/com/mojang/mojam/sound/SoundPlayer.java
@@ -180,7 +180,6 @@ public class SoundPlayer implements ISoundPlayer {
 				// effect.
 				return playSound(sourceName, x, y, false, index + 1);
 			}
-			getSoundSystem().stop(indexedSourceName);
 			getSoundSystem().setPriority(indexedSourceName, false);
 			getSoundSystem().setPosition(indexedSourceName, x, y, 0);
 			getSoundSystem().setAttenuation(indexedSourceName, SoundSystemConfig.ATTENUATION_ROLLOFF);
@@ -188,7 +187,6 @@ public class SoundPlayer implements ISoundPlayer {
 			getSoundSystem().setPitch(indexedSourceName, 1.0f);
 			soundVolume = Options.getAsFloat(Options.SOUND, "1.0f");
 			getSoundSystem().setVolume(indexedSourceName, soundVolume);
-			getSoundSystem().activate(indexedSourceName);
 			getSoundSystem().play(indexedSourceName);
 			return true;
 		}


### PR DESCRIPTION
The annoying sound problem I tried to fix with Issue #663 still bugs me. Using `cull()` and 
flushing the sound buffer to often wasn't the best solution.

So here's my next try. I analyzed the code and came to the conclusion that the `stop()` method is not needed. If a sound source is not loaded, it gets loaded. If it is already loaded and playing, the method returns. In both cases the explicit call of `stop()` is unnecessary in my opinion. Anyone disagree?

BTW I removed activate() again as I inserted it because I used cull() instead of stop().
