### PR TITLE
Cleaner way to exit the game

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -16,6 +16,9 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -248,6 +251,7 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 		running = false;
 		soundPlayer.stopBackgroundMusic();
 		soundPlayer.shutdown();
+		System.exit(0);
 	}
 
 	private void init() {
@@ -725,7 +729,8 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 		guiFrame.pack();
 		guiFrame.setResizable(false);
 		guiFrame.setLocationRelativeTo(null);
-		guiFrame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		guiFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+		guiFrame.addWindowListener(newWindowClosinglistener());
 		ArrayList<BufferedImage> icoList = new ArrayList<BufferedImage>();
 		icoList.add(Art.icon32);
 		icoList.add(Art.icon64);
@@ -1036,7 +1041,7 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 			break;
 
 		case TitleMenu.EXIT_GAME_ID:
-			System.exit(0);
+			stop();
 			break;
 
 		case TitleMenu.RETURN_ID:
@@ -1190,5 +1195,13 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 	
 	public static int clampi(int val, int min, int max){
 		return (val < min) ? min : (val > max) ? max : val;
+	}
+	
+	private static WindowListener newWindowClosinglistener() {
+		return new WindowAdapter() {
+			public void windowClosing(WindowEvent winEvt) {
+				MojamComponent.instance.stop();
+			}
+		};
 	}
 }


### PR DESCRIPTION
I've changed the DefaultCloseOperation of the JFrame to ensure that MojamComponent's stop() is always called. 

We now can clean up everything necessary (like the soundsystem now) and we can ask the user if he really wants to exit the game rather than just killing it. ;)
