### PR TITLE
Fixed hp regeneration (the function was not getting called) [Fix:#796]

### DIFF
--- a/src/com/mojang/mojam/entity/mob/Mob.java
+++ b/src/com/mojang/mojam/entity/mob/Mob.java
@@ -158,6 +158,8 @@ public abstract class Mob extends Entity {
 		// Like apply buffs based to Health effects
 		regen = this.buffs.effectsOf(Buff.BuffType.HEALTH_MODIF, regen);
 		regen = this.buffs.effectsOf(Buff.BuffType.REGEN_RATE  , regen);
+
+		this.regenerateHealthBy( regen );
 	}
 	
 	public void regenerateHealthBy(float a) { 


### PR DESCRIPTION
Added call back to regenerateHealthBy(float) in onRegenTime().

It seemed to be removed during work on buff system.
#796
