### PR TITLE
Don't create Exit menu twice

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -249,12 +249,13 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 	}
 
 	public void stop(boolean exit) {
-		addMenu(new ExitMenu(GAME_WIDTH, GAME_HEIGHT));
 		if (exit) {		
 			running = false;
 			soundPlayer.stopBackgroundMusic();
 			soundPlayer.shutdown();
 			System.exit(0);
+		} else {
+			addMenu(new ExitMenu(GAME_WIDTH, GAME_HEIGHT));
 		}
 	}
 


### PR DESCRIPTION
The Exit menu was created twice. It doesn't matter as we are leaving the game immediately, but it was my code here and it was just lazy coding. 

Thanks @eirthepriest for the advice.
