### PR TITLE
Final fix of "Error in class 'SourceJava Sound'"

### DIFF
--- a/src/com/mojang/mojam/sound/SoundPlayer.java
+++ b/src/com/mojang/mojam/sound/SoundPlayer.java
@@ -180,7 +180,9 @@ public class SoundPlayer implements ISoundPlayer {
 				// effect.
 				return playSound(sourceName, x, y, false, index + 1);
 			}
-			getSoundSystem().stop(indexedSourceName);
+//			if (getSoundSystem().playing(indexedSourceName)) {
+				getSoundSystem().stop(indexedSourceName);
+//			}
 			getSoundSystem().setPriority(indexedSourceName, false);
 			getSoundSystem().setPosition(indexedSourceName, x, y, 0);
 			getSoundSystem().setAttenuation(indexedSourceName, SoundSystemConfig.ATTENUATION_ROLLOFF);


### PR DESCRIPTION
Damn it! Sometimes I'm just to blind to see. The sound just needs to get stopped if it's playing of course. I've just added an `if(isPlaying)` before the stop method and now everything works fine. It's just not possible that there are any side effects because of that fix. We may still have sound issues... well we **do** have sound issues, but I'm quite sure that I've finally got rid of:

```
Error in class 'SourceJava Sound'
    Channel null in method 'stop'
```
