### PR TITLE
fixing turrets so they do not try to shoot at ShopItems

### DIFF
--- a/src/com/mojang/mojam/entity/building/Turret.java
+++ b/src/com/mojang/mojam/entity/building/Turret.java
@@ -78,7 +78,7 @@ public class Turret extends Building implements IEditable {
     		double closestDist = 99999999.0f;
     		for (Entity e : entities) {
     			if (!(e instanceof Mob) || (e instanceof RailDroid && e.team == this.team) || e instanceof Bomb || e instanceof SpikeTrap || 
-    					e instanceof DropTrap)
+    					e instanceof DropTrap || e instanceof ShopItem)
     				continue;
     			if (!((Mob) e).isNotFriendOf(this))
     				continue;


### PR DESCRIPTION
Turrets were trying their hardest to kill shop items when placed near enemie spawn... fixed.
