### PR TITLE
Sand Border and Rail Tile Render Issue Fix

### DIFF
--- a/src/com/mojang/mojam/level/tile/FloorTile.java
+++ b/src/com/mojang/mojam/level/tile/FloorTile.java
@@ -118,6 +118,7 @@ public class FloorTile extends Tile {
     }	
 	
 	public boolean isSandTile(Tile tile) {
-		return (tile instanceof SandTile || tile instanceof UnpassableSandTile);
+		return (tile instanceof SandTile || tile instanceof UnpassableSandTile ||
+				(tile instanceof RailTile && this.isSandTile(((RailTile) tile).parent)));
 	}
 }


### PR DESCRIPTION
When a rail tile or unbreakable rail tile is placed on a sand tile
adjacent to a floor tile the correct sand border is not rendered.
![Incorrect rendering of border](http://i.imgur.com/p19VE.png)
