### PR TITLE
Turret Health and Placement Bug Fix (Issue #848)

### DIFF
--- a/src/com/mojang/mojam/entity/building/Turret.java
+++ b/src/com/mojang/mojam/entity/building/Turret.java
@@ -52,10 +52,6 @@ public class Turret extends Building implements IEditable {
 		setStartHealth(10);
 		freezeTime = 10;
 		areaBitmap = Bitmap.rangeBitmap(radius,RADIUS_COLOR);
-	}
-
-	@Override
-	public void init() {
 		makeUpgradeableWithCosts(new int[] { TitleMenu.difficulty.calculateCosts(500), 
 				TitleMenu.difficulty.calculateCosts(1000), 
 				TitleMenu.difficulty.calculateCosts(5000)});


### PR DESCRIPTION
Fix for Issue #848: When a turret was placed the
makeUpgradeableWithCosts() and thus the upgradeComplete() methods were
called unnecessarily, causing the turrets maxHealth to be incremented
by 10 and its heath to reset. This was fixed by moving the makeUpgradable
call from init to the constructor similar to the harvester.
