### PR TITLE
Update src/com/mojang/mojam/MojamComponent.java

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -761,6 +761,11 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 	}
 
 	public static void main(String[] args) {
+		//attempt OpenGL Acceleration
+		
+		System.setProperty("sun.java2d.opengl", "True");
+		//True for verbose console output, true for silent
+		
 		Options.loadProperties();
 		MojamComponent mc = new MojamComponent();
 		guiFrame = new JFrame(GAME_TITLE);


### PR DESCRIPTION
This speeds up Java2D by silently converting all image operations to OpenGL calls. The Java2D buffer strategy cannot be used with OpenGL acceleration, so someone would need to write a custom back buffer flipping class.
