### PR TITLE
Fix issue #89: player ported to top-left of map

### DIFF
--- a/src/com/mojang/mojam/entity/Player.java
+++ b/src/com/mojang/mojam/entity/Player.java
@@ -894,10 +894,13 @@ public class Player extends Mob implements LootCollector {
      * @param y Y coordinate
      */
     public void setAimByMouse(int x, int y) {
-        mouseAiming = true;
-        aimVector.set(x, y);
-        aimVector.normalizeSelf();
-        updateFacing();
+    	/* Only update aim if vector has direction */
+    	if (x != 0 || y != 0) {
+	        mouseAiming = true;
+	        aimVector.set(x, y);
+	        aimVector.normalizeSelf();
+	        updateFacing();
+    	}
     }
 
     /**


### PR DESCRIPTION
Fix issue #89
Cause was placing an active mouse cursor at the direct
center of the character (causing the aim vector to have
no direction) AND firing.

You get warning output even if you aren't firing, but
you suffer no ill effect. If you are firing, then
you get ported to the top-left of the map.

Fix is not to update aim vector if the mouse is at
the center of the character.
