### PR TITLE
Removed console argument from allweapons

### DIFF
--- a/src/com/mojang/mojam/Console.java
+++ b/src/com/mojang/mojam/Console.java
@@ -350,7 +350,7 @@ public class Console implements KeyListener {
 		}
 	};
 
-	public Command allweapons = new Command("allweapons", 1, "Gives all weapons")
+	public Command allweapons = new Command("allweapons", 0, "Gives all weapons")
 	{
 		@Override
 		public void doCommand(String[] args)
@@ -405,7 +405,7 @@ public class Console implements KeyListener {
 	};
 
 	
-	public Command give = new Command("give", 1, "Gives a weapon")
+	public Command give = new Command("give", 1, "Gives a weapon or money")
 	{
 		@Override
 		public void doCommand(String[] args)


### PR DESCRIPTION
The command 'allweapons' specified an argument but it does not need one. Removed it so that unnecessary code is not run. Also I fixed the 'give' help text so people will know that the 'give' command can also give money.
