### PR TITLE
fixed issue #926 - added check so new ExitMenu is not put on top of stack if one is at the top already

### DIFF
--- a/src/com/mojang/mojam/MojamComponent.java
+++ b/src/com/mojang/mojam/MojamComponent.java
@@ -265,7 +265,7 @@ public class MojamComponent extends Canvas implements Runnable, MouseMotionListe
 			soundPlayer.stopBackgroundMusic();
 			soundPlayer.shutdown();
 			System.exit(0);
-		} else {
+		} else if(!(menuStack.peek() instanceof ExitMenu)){
 			menuStack.add(new ExitMenu(GAME_WIDTH, GAME_HEIGHT));
 		}
 	}


### PR DESCRIPTION
fixed issue #926 - added check so new ExitMenu is not put on top of stack if one is at the top already
