### PR TITLE
Fixed problem with Fonts in DownloadScreen.

### DIFF
--- a/src/com/mojang/mojam/MojamStartup.java
+++ b/src/com/mojang/mojam/MojamStartup.java
@@ -56,8 +56,13 @@ public class MojamStartup extends Canvas implements Runnable, ButtonListener {
     private DownloadScreen ds;
 
     public MojamStartup() {
+	if (MojamComponent.screen == null) {
 	screen = new MojamScreen(GAME_WIDTH, GAME_HEIGHT);
 	screen.loadResources();
+	MojamComponent.screen = screen;
+	}else{
+	screen = MojamComponent.screen;
+	}
 
 	MojamComponent.constants = new Constants();
 	MojamComponent.texts = new Texts(new Locale("en"));


### PR DESCRIPTION
Even if this fix was fast, this is a signal of a worst problems comming:
1- we have 2 static AbstractScreen objects (MojamComponent & MojamStartup).
2- Fonts are instanciated statically. If some class try to use Fonts before
MojamComponent.screen is set, NullPointerException will come.

For now, im giving priority to MojamComponent.screen one. MojamStartup will
use it if set, or create and set. MojamComponent will overwrite regardless
if its set or not.

To avoid exception, an easy solution would be create a static void
CreateFonts(AbstractScreen) and call it from *Screen constructors.

I think it is a big matter to do it w/o asking first.
